### PR TITLE
Add CI tests and document need for signed-off-by, DCO

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Contributors to the Fedora Project
+#
+# SPDX-License-Identifier: MIT
+
+name: CI
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  python-smoketests-ci:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    container: fedorapython/fedora-python-tox:latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install absolufy
+        run: |
+          python3 -m pip install absolufy-imports
+
+      - name: Enforce relative imports in package
+        run: >
+          find mirrors_countme -name \*.py -print0
+          | xargs -0 absolufy-imports --never
+
+  backend-ci:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    container: fedorapython/fedora-python-tox:latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Mark the directory as safe for git
+        run: git config --global --add safe.directory $PWD
+
+      - name: Install base Python dependencies
+        run: |
+          python3 -m pip install --upgrade tox
+
+      - name: execute tox
+        run: tox

--- a/README.md
+++ b/README.md
@@ -212,6 +212,14 @@ In practice, this is a three-part process:
   * Might end up in different places/forms in the future
   * Can also run countme-weekly-totals-ui.sh command to see text data easily.
 
+## Contributing
+
+You need to be legally allowed to submit any contribution to this project.
+What this means in detail is laid out at the [Developer Certificate of Origin]
+website. The mechanism by which you certify this is adding a `Signed-off-by`
+trailer to git commit log messages, you can do this by using the
+`--signoff/-s` option to `git commit`.
+
 [^IPvBeefy]: Don't worry, 240.159.140.173 is a fake IP address. Actually,
              it's the 4-byte UTF-8 encoding for &#x1f32d;, U+1F32D HOT DOG.
 
@@ -224,3 +232,4 @@ In practice, this is a three-part process:
 [libdnf/utils/os-release.cpp:getUserAgent()]: https://github.com/rpm-software-management/libdnf/blob/0.47.0/libdnf/utils/os-release.cpp#L108
 [libdnf/repo/Repo.cpp:addCountmeFlag()]: https://github.com/rpm-software-management/libdnf/blob/0.47.0/libdnf/repo/Repo.cpp#L1051
 [libdnf/repo/Repo.cpp:COUNTME\_BUCKETS]: https://github.com/rpm-software-management/libdnf/blob/0.47.0/libdnf/repo/Repo.cpp#L92
+[Developer Certificate of Origin]: https://developercertificate.org


### PR DESCRIPTION
Fixes: #6

~~As I understand it, submitting this PR should kick off the tests.~~

The changes to CI configuration don’t take effect until merged, so I've made a copy of the repo with them applied [here](/nphilipp-playground/mirrors-countme).

The smoke tests should succeed but the unit tests run through tox should fail until #2 is done, see nphilipp-playground/mirrors-countme#1.