### PR TITLE
Don’t use the `python` label for Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,10 +22,6 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
-      "matchLanguages": ["python"],
-      "addLabels": ["python"]
-    },
-    {
       "matchDepTypes": ["devDependencies"],
       "automerge": true,
       "groupName": "dev dependencies"


### PR DESCRIPTION
The project mainly consists of Python code, so this label is superfluous.