### PR TITLE
Don’t preprocess log files with grep

### DIFF
--- a/mirrors_countme/parse.py
+++ b/mirrors_countme/parse.py
@@ -1,27 +1,4 @@
-import subprocess
-import sys
-from contextlib import contextmanager
-from pathlib import Path
-from tempfile import NamedTemporaryFile
-from typing import Iterator
-
 from .progress import ReadProgress
-
-
-@contextmanager
-def pre_process(filepath: str | Path) -> Iterator[str]:
-    filepath = Path(filepath)
-    with NamedTemporaryFile(
-        prefix=f"mirrors-countme-{filepath.name}-",
-        suffix=".preprocessed",
-    ) as tmpfile:
-        print(f"Preprocessing file: {filepath}", file=sys.stderr)
-        cmd = ["grep", "countme", str(filepath)]
-        r = subprocess.run(cmd, stdout=tmpfile)
-        if r.returncode != 0:
-            print(f"Preprocessing file failed, returning original: {filepath}", file=sys.stderr)
-            yield str(filepath)
-        yield tmpfile.name
 
 
 def parse_from_iterator(
@@ -76,7 +53,7 @@ def parse(
     logs=None,
 ):
     parse_from_iterator(
-        ReadProgress(logs, display=progress, pre_process=pre_process),
+        ReadProgress(logs, display=progress),
         writer=writer,
         matcher=matcher,
         matchmode=matchmode,

--- a/mirrors_countme/progress.py
+++ b/mirrors_countme/progress.py
@@ -22,9 +22,6 @@ import lzma
 import os
 import subprocess
 import sys
-from contextlib import contextmanager
-from pathlib import Path
-from typing import Iterator
 
 from .regex import LOG_DATE_RE
 
@@ -83,27 +80,20 @@ def log_total_size(logfn):
         return os.stat(logfn).st_size
 
 
-@contextmanager
-def no_preprocess(filepath: str | Path) -> Iterator[str]:
-    yield str(filepath)
-
-
 class ReadProgressBase:
-    def __init__(self, logs, display=True, pre_process=no_preprocess):
+    def __init__(self, logs, display=True):
         """logs should be a sequence of line-iterable file-like objects.
         if display is False, no progress output will be printed."""
         self.logs = logs
         self.display = display
-        self.pre_process = pre_process
 
     def __iter__(self):
         """Iterator for ReadProgress; yields a sequence of line-iterable
         file-like objects (one for each log in logs)."""
         for num, logfn in enumerate(self.logs):
-            with self.pre_process(logfn) as processed_log:
-                logf = log_reader(processed_log)
-                total = log_total_size(processed_log)
-                yield self._iter_log_lines(logf, num, total)
+            logf = log_reader(logfn)
+            total = log_total_size(logfn)
+            yield self._iter_log_lines(logf, num, total)
 
     def _iter_log_lines(self, logf, num, total):
         # Make a progress meter for this file


### PR DESCRIPTION
Previously, this used `grep` to filter log lines and only process those actually containing the string `countme`. However, this wouldn’t work with compressed log files and also can’t be done if we want to resurrect traditional statistics based on plain individual IP addresses.

Fixes: #21, #38