### PR TITLE
Create indexes before writing data

### DIFF
--- a/mirrors_countme/parse.py
+++ b/mirrors_countme/parse.py
@@ -2,7 +2,7 @@ from .progress import ReadProgress
 
 
 def parse_from_iterator(
-    lines,
+    logfiles,
     *,
     writer,
     matcher,
@@ -15,7 +15,7 @@ def parse_from_iterator(
     if header or sqlite:
         writer.write_header()
 
-    for logf in lines:
+    for logf in logfiles:
         # Make an iterator object for the matching log lines
         match_iter = iter(matcher(logf))
 

--- a/mirrors_countme/parse.py
+++ b/mirrors_countme/parse.py
@@ -58,7 +58,7 @@ def parse(
         matcher=matcher,
         matchmode=matchmode,
         header=header,
-        sqlite=header,
+        sqlite=sqlite,
         dupcheck=dupcheck,
         index=index,
     )

--- a/mirrors_countme/totals.py
+++ b/mirrors_countme/totals.py
@@ -168,6 +168,9 @@ def totals(*, countme_totals, countme_raw=None, progress=False, csv_dump=None):
     if countme_raw:
         rawdb = RawDB(countme_raw)
 
+        # Make sure we index them by time.
+        totals.write_index()
+
         # Check to see if there's any new weeks to get data for
         complete_weeks = sorted(rawdb.complete_weeks())
         newest_totals = totals.maxtime or -1
@@ -196,9 +199,6 @@ def totals(*, countme_totals, countme_raw=None, progress=False, csv_dump=None):
             # Write the resulting totals into countme_totals
             totals.write_items((hits,) + bucket for bucket, hits in hitcount.items())
             prog.close()
-
-        # Oh and make sure we index them by time.
-        totals.write_index()
 
     # Was a CSV dump requested?
     if csv_dump:

--- a/mirrors_countme/writers.py
+++ b/mirrors_countme/writers.py
@@ -47,6 +47,9 @@ class ItemWriter:
     def write_header(self):
         pass
 
+    def commit(self):
+        pass
+
     def write_index(self):
         pass
 
@@ -144,9 +147,12 @@ class SQLiteWriter(ItemWriter):
         with self._connection:
             self._connection.executemany(self._insert_item, items)
 
+    def commit(self):
+        self._connection.commit()
+
     def write_index(self):
         self._cursor.execute(self._create_time_index)
-        self._connection.commit()
+        self.commit()
 
     def has_item(self, item):
         """Return True if a row matching `item` exists in this database."""

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,0 +1,120 @@
+from collections.abc import Generator
+from itertools import chain, repeat
+from unittest import mock
+
+import pytest
+
+from mirrors_countme.parse import parse, parse_from_iterator
+
+
+@pytest.mark.parametrize(
+    "testcase",
+    (
+        "happy-path",
+        "without-header",
+        "without-countme-workaround",
+        "without-dupcheck",
+        "without-index",
+    ),
+)
+def test_parse_from_iterator(testcase):
+    lines = [
+        "not this",
+        "this als not",
+        "but this (pick me)",
+        "and this (pick me, too)",
+    ]
+    logf = mock.Mock(lines=lines)
+    writer = mock.Mock()
+
+    class matcher:
+        def __init__(self, logf):
+            self.logf = logf
+
+        def __iter__(self):
+            for line in logf.lines:
+                if "pick me" in line:
+                    yield (line,)
+
+    manager = mock.Mock()
+    manager.attach_mock(writer.write_header, "write_header")
+    manager.attach_mock(writer.write_index, "write_index")
+    manager.attach_mock(writer.has_item, "has_item")
+    writer.has_item.side_effect = chain([True], repeat(False))
+    manager.attach_mock(writer.write_item, "write_item")
+    manager.attach_mock(writer.commit, "commit")
+    manager.attach_mock(writer.write_items, "write_items")
+
+    header = sqlite = "without-header" not in testcase
+    matchmode = "countme" if "without-countme-workaround" not in testcase else "mirrors"
+    dupcheck = "without-dupcheck" not in testcase
+    index = "without-index" not in testcase
+
+    parse_from_iterator(
+        [logf],
+        writer=writer,
+        matcher=matcher,
+        header=header,
+        sqlite=sqlite,
+        matchmode=matchmode,
+        dupcheck=dupcheck,
+        index=index,
+    )
+
+    expected_calls = []
+
+    if "without-header" not in testcase:
+        expected_calls.append(mock.call.write_header())
+
+    if "without-index" not in testcase:
+        expected_calls.append(mock.call.write_index())
+
+    if "without-dupcheck" not in testcase:
+        had_item = False
+        for line in lines:
+            if "pick me" in line:
+                expected_calls.append(mock.call.has_item((line,)))
+                if had_item:
+                    expected_calls.append(mock.call.write_item((line,)))
+                else:
+                    had_item = True
+        expected_calls.append(mock.call.commit())
+        assert manager.mock_calls == expected_calls
+    else:
+        mock_calls = manager.mock_calls[:-1]
+        assert mock_calls == expected_calls
+
+        # This one is hard to mock precisely, its argument is an on-the-fly-created generator
+        last_call = manager.mock_calls[-1]
+        assert last_call[0] == "write_items"
+        assert len(last_call[1]) == 1
+        assert isinstance(last_call[1][0], Generator)
+        assert len(last_call[2]) == 0
+
+
+@pytest.mark.parametrize("use_default", (True, False))
+@mock.patch("mirrors_countme.parse.parse_from_iterator")
+@mock.patch("mirrors_countme.parse.ReadProgress")
+def test_parse(ReadProgress, parse_from_iterator, use_default):
+    kwargs = {
+        "writer": object(),
+        "matcher": object(),
+        "header": object(),
+        "sqlite": object(),
+        "dupcheck": object(),
+        "index": object(),
+    }
+
+    if use_default:
+        expected_kwargs = kwargs.copy()
+        expected_kwargs["matchmode"] = "countme"
+    else:
+        kwargs["matchmode"] = object()
+        expected_kwargs = kwargs
+
+    ReadProgress.return_value = read_progress = object()
+    expected_args = (read_progress,)
+
+    parse(**kwargs)
+
+    parse_from_iterator.assert_called_once_with(*expected_args, **expected_kwargs)


### PR DESCRIPTION
Previously, for the first time a raw database is written, checking for duplicates takes a very long time.

Also, add unit tests for the `parse` module.

Fixes: #51

Plus some small issues that became apparent when writing the new tests.