### PR TITLE
RPM package enablement

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1583,4 +1583,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "c2d91b4d41fc3abcb512cecde06ec7da3159738570a1a22109b3dd1bc2a0964f"
+content-hash = "8a977b2fa4410f954d787b28f35faf387c6dd4ff332076f670932892153a3048"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,13 @@ authors = [
 ]
 license = "GPL-3.0-or-later"
 readme = "README.md"
-packages = [{include = "mirrors_countme"}]
+packages = [
+    { include = "mirrors_countme" },
+]
+include = [
+    { path = "scripts/*.sh", format = "sdist" },
+    { path = "tests", format = "sdist" },
+]
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ include = [
     { path = "tests", format = "sdist" },
 ]
 
+[tool.poetry.build]
+generate-setup-file = true
+
 [tool.poetry.dependencies]
 python = "^3.11"
 poetry = "^1.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ generate-setup-file = true
 
 [tool.poetry.dependencies]
 python = "^3.11"
-poetry = "^1.4.2"
+poetry = "^1.3.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"

--- a/tests/test_integrate.py
+++ b/tests/test_integrate.py
@@ -153,7 +153,7 @@ def log_data(draw):
     return sorted(((date, ip, draw(repo)) for ip in ips for date in dates), key=lambda x: x[0])
 
 
-@settings(suppress_health_check=(HealthCheck.too_slow,))
+@settings(suppress_health_check=(HealthCheck.too_slow,), deadline=datetime.timedelta(seconds=1))
 @given(loglines=log_data())
 def test_log(loglines):
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
```
commit 01bc0aca9d1aa4ab308dd370c6ef411ea4b7d97c
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Jun 26 12:24:36 2023 +0200

    Extend deadline for hypothesis-based test_log()
    
    Running the tests when building an RPM package exceeded the default
    deadline, maybe because the builders are less powerful or busier.
    
    Related: #59
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 0d5c91d904c45f98449442c8d94a7f7957d89181
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Jun 26 12:27:43 2023 +0200

    Package all the files
    
    Previously, only the `mirrors_countme` package was shipped with the
    tarball. This adds the tests and shell scripts.
    
    Related: #59
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit fc67d8d92a12dde69d99ae6c92a7c0186d2b9a90
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Jun 26 12:31:44 2023 +0200

    Generate setup.py
    
    This is needed for OS versions where poetry is too old or even missing
    entirely.
    
    Related: #59
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit f4b6e443f79b9c880d12ae24a7d4cac43d53e845
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Jun 26 12:29:08 2023 +0200

    Allow older versions of Poetry
    
    Related: #59
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```