### PR TITLE
Cope with pre-countme log data

### DIFF
--- a/mirrors_countme/output_items.py
+++ b/mirrors_countme/output_items.py
@@ -68,7 +68,8 @@ class MirrorItem(NamedTuple):
 class CountmeItem(NamedTuple):
     """
     A "countme" match item.
-    Includes the countme value and libdnf User-Agent fields.
+    Includes the countme value and libdnf User-Agent fields, can blank missing data
+    so we can log old data.
     """
 
     timestamp: int

--- a/mirrors_countme/parse.py
+++ b/mirrors_countme/parse.py
@@ -1,6 +1,19 @@
 from .progress import ReadProgress
 
 
+# Given a match iter, we replace the None values with ""
+def _convert_none_members(miter):
+    for item in miter:
+        if None in item:
+            n = []
+            for val in item:
+                if val is None:
+                    val = ""
+                n.append(val)
+            item = tuple(n)
+        yield item
+
+
 def parse_from_iterator(
     logfiles,
     *,
@@ -22,9 +35,9 @@ def parse_from_iterator(
         # Make an iterator object for the matching log lines
         match_iter = iter(matcher(logf))
 
-        # TEMP WORKAROUND: filter out match items with missing values
+        # WORKAROUND: filter or blank out match items with missing values
         if matchmode == "countme":
-            match_iter = (i for i in match_iter if None not in i)
+            match_iter = _convert_none_members(match_iter)
 
         if dupcheck:
             # Duplicate data check (for sqlite output)

--- a/mirrors_countme/regex.py
+++ b/mirrors_countme/regex.py
@@ -87,7 +87,7 @@ LOG_PATTERN_FIELDS = {
     "user_agent": ".+?",
 }
 
-# A regex for libdnf/rpm-ostree user-agent strings.
+# A regex for optional libdnf/rpm-ostree user-agent strings.
 # Examples:
 #   "libdnf/0.35.5 (Fedora 32; workstation; Linux.x86_64)"
 #   "libdnf (Fedora 32; generic; Linux.x86_64)"
@@ -116,7 +116,7 @@ COUNTME_USER_AGENT_PATTERN = (
     r"(?P<os_variant>[0-9a-z._-]*);\s"
     r"(?P<os_canon>[\w./]+)\."
     r"(?P<os_arch>\w+)"
-    r"\)"
+    r'\)|[^"]*'
 )
 COUNTME_USER_AGENT_RE = re.compile(COUNTME_USER_AGENT_PATTERN)
 LIBDNF_USER_AGENT_RE = re.compile(COUNTME_USER_AGENT_PATTERN)

--- a/mirrors_countme/totals.py
+++ b/mirrors_countme/totals.py
@@ -128,6 +128,8 @@ class CSVCountItem(NamedTuple):
 
 
 class RawDB(SQLiteReader):
+    START_WEEKNUM = COUNTME_START_WEEKNUM
+
     def __init__(self, filename, **kwargs):
         super().__init__(filename, CountmeItem, tablename="countme_raw", **kwargs)
 
@@ -149,11 +151,11 @@ class RawDB(SQLiteReader):
         if self.mintime is None:
             return []
         # startweek can't be earlier than the first week of data
-        startweek = max(weeknum(self.mintime), COUNTME_START_WEEKNUM)
+        startweek = max(weeknum(self.mintime), self.START_WEEKNUM)
         # A week is provisional until the LOG_JITTER_WINDOW expires, so once
         # tsmax minus LOG_JITTER_WINDOW ticks over into a new weeknum, that
         # weeknum is the provisional one. So...
-        provweek = max(weeknum(self.maxtime - LOG_JITTER_WINDOW), COUNTME_START_WEEKNUM)
+        provweek = max(weeknum(self.maxtime - LOG_JITTER_WINDOW), self.START_WEEKNUM)
         return range(startweek, provweek)
 
     def week_iter(self, weeknum, select: tuple | list):
@@ -172,6 +174,8 @@ class RawDB(SQLiteReader):
 
 
 class RawDBU(RawDB):
+    START_WEEKNUM = 0
+
     def __init__(self, fp, **kwargs):
         super().__init__(fp, **kwargs)
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -3,8 +3,31 @@ from itertools import chain, repeat
 from unittest import mock
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
-from mirrors_countme.parse import parse, parse_from_iterator
+from mirrors_countme.parse import _convert_none_members, parse, parse_from_iterator
+
+
+@given(
+    values_tuple=st.one_of(
+        st.tuples(),
+        st.tuples(
+            *(
+                st.one_of(
+                    st.nothing(),
+                    st.one_of(st.none(), st.text()),
+                )
+                for items in range(3)
+            )
+        ),
+    )
+)
+def test__convert_none_members(values_tuple):
+    input_iterables = iter([values_tuple])
+    expected_result = tuple("" if val is None else val for val in values_tuple)
+
+    assert list(_convert_none_members(input_iterables))[0] == expected_result
 
 
 @pytest.mark.parametrize(

--- a/tests/test_regex.py
+++ b/tests/test_regex.py
@@ -85,7 +85,7 @@ COUNTME_USER_AGENT_RE_INPUTS_RESULTS = [
 ]
 
 
-COUNTME_USER_AGENT_RE_INVALID_INPUTS = [
+COUNTME_USER_AGENT_RE_NULL_INPUTS = [
     (
         r"16.160.95.167 - - [31/May/2021:00:00:02 +0000] "
         r'"GET /badpath?repo=epel-8&arch=x86_64&infra=stock&content=almalinux&countme=2 HTTP/1.1" '
@@ -101,10 +101,12 @@ def test_countme_user_agent_re(test_case):
     assert groups == expected_output
 
 
-@pytest.mark.parametrize("test_case", COUNTME_USER_AGENT_RE_INVALID_INPUTS)
+@pytest.mark.parametrize("test_case", COUNTME_USER_AGENT_RE_NULL_INPUTS)
 def test_countme_user_agent_re_invalid(test_case):
-    invalid_input = test_case
-    assert COUNTME_USER_AGENT_RE.match(invalid_input) is None
+    null_input = test_case
+    groupvals = COUNTME_USER_AGENT_RE.match(null_input).groups()
+    assert len(groupvals)
+    assert all(groupval is None for groupval in groupvals)
 
 
 LOG_DATE_RE_INPUTS_RESULTS = [

--- a/tests/test_totals.py
+++ b/tests/test_totals.py
@@ -10,7 +10,6 @@ from mirrors_countme import totals, util
 from mirrors_countme.constants import (
     COUNTME_EPOCH,
     COUNTME_EPOCH_ORDINAL,
-    COUNTME_START_WEEKNUM,
     LOG_JITTER_WINDOW,
     WEEK_LEN,
 )
@@ -132,9 +131,9 @@ class TestRawDB:
         if mintime is None:
             assert result == []
         else:
-            assert result.start == max(util.weeknum(mintime), COUNTME_START_WEEKNUM)
+            assert result.start == max(util.weeknum(mintime), self.cls.START_WEEKNUM)
             assert result.stop == max(
-                util.weeknum(maxtime - LOG_JITTER_WINDOW), COUNTME_START_WEEKNUM
+                util.weeknum(maxtime - LOG_JITTER_WINDOW), self.cls.START_WEEKNUM
             )
 
     def test_week_iter(self, rawdb):


### PR DESCRIPTION
- Cope with potentially missing query parameters (os_\*, repo_\*), so we don’t skip over non-countme log lines. This replaces missing values with empty strings.
- Remove the temporary workaround that skipped over such log lines.
- Let RawDBU process log data from before the countme scheme was introduced.

Fixes: #109