### PR TITLE
Fix Python 3.15 compatibility: NamedTuple keyword argument syntax removed

### DIFF
--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -152,7 +152,7 @@ class TestSQLiteWriter:
             sqltype.replace(" ", "_"): typehint
             for typehint, sqltype in item_writer.SQL_TYPE.items()
         }
-        AllTypesItemTuple = NamedTuple("AllTypesItemTuple", **fieldname_typehints)
+        AllTypesItemTuple = NamedTuple("AllTypesItemTuple", list(fieldname_typehints.items()))
         with mock.patch.object(item_writer, "_itemtuple", new=AllTypesItemTuple):
             # Can’t use item_writer._fields because it’s initialited with another type.
             for fieldname in AllTypesItemTuple._fields:


### PR DESCRIPTION
Python 3.15 removed the undocumented keyword argument syntax for typing.NamedTuple(). Use the list-of-tuples functional syntax instead.